### PR TITLE
fix: skip Kaleido v0.2.1.post1 in Femder runtime dependencies

### DIFF
--- a/requirements/runtime_requirements.txt
+++ b/requirements/runtime_requirements.txt
@@ -2,7 +2,7 @@
 cloudpickle
 gmsh
 ipython
-kaleido
+kaleido!=0.2.1.post1 # SEE: https://github.com/plotly/Kaleido/issues/176
 matplotlib
 meshio
 mkl


### PR DESCRIPTION
The Kaleido version was not explicitly defined in requirements/runtime_requirements.txt. However, version v0.2.1.post1 (the latest version as of this commit) fails to install with some package managers, such as Poetry and UV.

As a result, Kaleido is now fixed to version v0.2.1, meaning the latest available version for the package is v0.2.1 instead of v0.2.1.post1.

This change will have no impact on most users, as v0.2.1.post1 only adds support for ARM32 architectures.

SEE: https://github.com/plotly/Kaleido/issues/176
SEE: https://github.com/plotly/Kaleido/releases/tag/v0.2.1.post1